### PR TITLE
Replacement of tests for Spotify mockup data

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,15 +21,22 @@ jobs:
       with:
           python-version: '3.9.x'
         
-    - uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('server/requirements.txt') }}
+    #- uses: actions/cache@v4
+    #  with:
+    #    path: ${{ env.pythonLocation }}
+    #    key: ${{ env.pythonLocation }}-${{ hashFiles('server/requirements.txt') }}
+
+    - name: Force install pip 23.2.1 using get-pip.py
+      run: |
+        curl -sS https://bootstrap.pypa.io/pip/get-pip.py -o get-pip.py
+        python get-pip.py pip==23.2.1
+
+    - name: Confirm pip version
+      run: pip --version
 
     - name: Install dependencies
       run: |
         cd ./server
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest
         pip install pylint

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Force install pip 23.2.1 using get-pip.py
       run: |
-        curl -sS https://bootstrap.pypa.io/pip/get-pip.py -o get-pip.py
+        curl -sS https://bootstrap.pypa.io/pip/3.9/get-pip.py -o get-pip.py
         python get-pip.py pip==23.2.1
 
     - name: Confirm pip version

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,8 +30,7 @@ jobs:
 
       - name: Force install pip 23.2.1 using get-pip.py
         run: |
-          curl -sS https://bootstrap.pypa.io/pip/get-pip.py -o get-pip.py
-          python get-pip.py pip==23.2.1
+           python -m pip install --upgrade pip==23.2.1
 
       - name: Confirm pip version
         run: pip --version

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,15 +22,22 @@ jobs:
         with:
           python-version: '3.9.x'
 
-      - name: Setup cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('server/requirements.txt') }}
+      #- name: Setup cache
+      #  uses: actions/cache@v4
+      #  with:
+      #    path: ${{ env.pythonLocation }}
+      #    key: ${{ env.pythonLocation }}-${{ hashFiles('server/requirements.txt') }}
+
+      - name: Force install pip 23.2.1 using get-pip.py
+        run: |
+          curl -sS https://bootstrap.pypa.io/pip/get-pip.py -o get-pip.py
+          python get-pip.py pip==23.2.1
+
+      - name: Confirm pip version
+        run: pip --version
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r ./server/requirements.txt
           pip install pytest-cov
 

--- a/server/project/blueprints/music_detail_bp.py
+++ b/server/project/blueprints/music_detail_bp.py
@@ -120,7 +120,10 @@ def last_fm_info(artist, track, mbid):
               '&artist=' + artist + \
               '&track=' + track + '&autocorrect=1&format=json'
     res = requests.get(url, timeout=10)
-    return json.loads(res.text)
+    try:
+        return res.json()
+    except ValueError:
+        raise RuntimeError(f"Spotify returned invalid JSON: {res.text}")
 
 
 def get_acousticbrainz_data(mbid):
@@ -286,7 +289,17 @@ def request_spotify_data(url, full_url=False):
                'Content-Type':'application/json'}
     res = requests.get(full_url, headers=headers,timeout=10)
     # print('spotify request data', json.loads(res.text))
-    return json.loads(res.text)
+    # critical fix: handle HTTP errors first
+    if not res.ok:
+        raise RuntimeError(
+            f"Spotify request failed ({res.status_code}): {res.text}"
+        )
+
+    # critical fix: safe JSON parsing
+    try:
+        return res.json()
+    except ValueError:
+        raise RuntimeError(f"Invalid JSON from Spotify: {res.text}")
 
 
 def get_spotify_token():

--- a/server/project/blueprints/result_bp.py
+++ b/server/project/blueprints/result_bp.py
@@ -207,6 +207,8 @@ def validate():
 
     overview = load_results_overview()
     overview_index = id_to_index(overview, result_id)
+    if overview_index == -1:
+        return BAD_REQUEST_RESPONSE
     result = overview['all_results'][overview_index]
     amount = int(json_data.get('amount', 1))
     queue.add_validation(overview_index, file_path, amount, result)

--- a/server/project/models/result_loader.py
+++ b/server/project/models/result_loader.py
@@ -12,6 +12,7 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 import os
+import shutil
 from fairreckitlib.data.set.dataset import add_dataset_columns as add_data_columns
 
 from fairreckitlib.data.filter.filter_config import FilterConfig
@@ -188,7 +189,9 @@ def rename_headers(dataset_name, matrix_name, df_subset):
     if dataset is not None and not dataset.get_matrix_config(matrix_name) is None:
         item = dataset.get_matrix_config(matrix_name).item.key
         user = dataset.get_matrix_config(matrix_name).user.key
-        df_subset.rename(columns={'user':user, 'item':item}, inplace=True)
+        df_subset = df_subset.copy()
+        df_subset = df_subset.rename(columns={'user':user, 'item':item})
+    return df_subset
 
 
 def sort_headers(df_subset):
@@ -336,6 +339,6 @@ def filter_results(dataframe, dataset_name, matrix_name, filters):
     finally:
         # Clean up temporary directory
         if os.path.exists(temp_filter_dir):
-            os.rmdir(temp_filter_dir)  # Clean up the directory
+            shutil.rmtree(temp_filter_dir)  # Clean up the directory (recursively)
 
     return dataframe

--- a/server/tests/test_music_detail.py
+++ b/server/tests/test_music_detail.py
@@ -14,11 +14,56 @@ Utrecht University within the Software Project course.
 
 import numpy as np
 from sewar.full_ref import uqi
+from unittest.mock import patch, MagicMock
+from io import BytesIO
 from PIL import Image
+
 from project.blueprints.music_detail_bp import collage, get_acousticbrainz_data
 from project.blueprints.music_detail_bp import request_spotify_data
 
+
 URL_PREFIX = '/api/music'
+
+
+def make_fake_image_bytes(size=(10, 10), color=(255, 0, 0)):
+    """Build real, openable PNG bytes so Image.open() doesn't choke."""
+    img = Image.new('RGB', size, color)
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return buf.getvalue()
+
+
+FAKE_PLAYLIST_RESPONSE = {
+    "items": [
+        {"track": {"album": {"images": [
+            {"url": "http://fake/img1_large.jpg"},
+            {"url": "http://fake/img1_small.jpg"},
+        ]}}},
+        {"track": {"album": {"images": [
+            {"url": "http://fake/img2_large.jpg"},
+            {"url": "http://fake/img2_small.jpg"},
+        ]}}},
+    ],
+    "total": 2,
+}
+
+FAKE_ALBUM_SEARCH_RESPONSE = {
+    "albums": {
+        "items": [
+            {"images": [{"url": "http://fake/a1_large.jpg"}, {"url": "http://fake/a1_small.jpg"}]},
+            {"images": [{"url": "http://fake/a2_large.jpg"}, {"url": "http://fake/a2_small.jpg"}]},
+        ],
+        "next": None,
+    }
+}
+
+FAKE_SEARCH_RESPONSE = {
+    "tracks": {
+        "items": [
+            {"id": "fake_id", "album": {"name": "Scatman (ski-ba-bop-ba-dop-bop)"}}
+        ]
+    }
+}
 
 
 def test_acousticbrainz_data():
@@ -27,15 +72,25 @@ def test_acousticbrainz_data():
     assert ab_data
 
 
-def test_background(client):
+@patch('project.blueprints.music_detail_bp.requests.get')
+@patch('project.blueprints.music_detail_bp.request_spotify_data')
+def test_background(mock_spotify_data, mock_requests_get, client):
     """Test if a background is successfully generated.
 
     Args:
         client: The client component used to send requests to the server
     """
-    response = client.get(URL_PREFIX + '/background')
-    assert response.status_code == 200
-    assert response.data == b'Background saved'
+    mock_spotify_data.return_value = FAKE_PLAYLIST_RESPONSE
+
+    fake_image_response = MagicMock()
+    fake_image_response.content = make_fake_image_bytes()
+    mock_requests_get.return_value = fake_image_response
+
+    with patch('project.blueprints.music_detail_bp.collage') as mock_collage:
+        response = client.get(URL_PREFIX + '/background')
+        assert response.status_code == 200
+        assert response.data == b'Background saved'
+        mock_collage.assert_called_once()
 
 
 def test_collage():
@@ -50,19 +105,40 @@ def test_collage():
     assert uqi(np.asanyarray(test_output), np.asanyarray(result)) > 0.8
 
 
-def test_unique_album_background(client):
+@patch('project.blueprints.music_detail_bp.requests.get')
+@patch('project.blueprints.music_detail_bp.request_spotify_data')
+def test_unique_album_background(mock_spotify_data, mock_requests_get, client):
     """Test if a background is successfully generated.
 
     Args:
         client: The client component used to send requests to the server
     """
-    response = client.get(URL_PREFIX + '/unique-album-background')
-    assert response.status_code == 200
-    assert response.data == b'Background saved'
+    mock_spotify_data.return_value = FAKE_ALBUM_SEARCH_RESPONSE
+
+    fake_image_response = MagicMock()
+    fake_image_response.content = make_fake_image_bytes()
+    mock_requests_get.return_value = fake_image_response
+
+    with patch('project.blueprints.music_detail_bp.collage') as mock_collage:
+        response = client.get(URL_PREFIX + '/unique-album-background')
+        assert response.status_code == 200
+        assert response.data == b'Background saved'
+        mock_collage.assert_called_once()
 
 
-def test_spotify_data():
+@patch('project.blueprints.music_detail_bp.get_spotify_token')
+@patch('project.blueprints.music_detail_bp.requests.get')
+def test_spotify_data(mock_requests_get, mock_get_token):  # pylint: disable=unused-argument
     """Test if Spotify track data gets successfully requested."""
+    from project.models import token as tok
+    tok.access_token = 'fake_token'
+    tok.token_type = 'Bearer'
+
+    fake_response = MagicMock()
+    fake_response.ok = True
+    fake_response.json.return_value = FAKE_SEARCH_RESPONSE
+    mock_requests_get.return_value = fake_response
+
     url = 'search?q=scatman%20john&type=track'
     result = request_spotify_data(url)
     assert "Scatman" in result['tracks']['items'][0]['album']['name']

--- a/server/tests/test_result.py
+++ b/server/tests/test_result.py
@@ -179,6 +179,8 @@ def test_headers(client):
     assert result2
 
 
+@patch('project.models.result_storage.RESULTS_OVERVIEW_PATH', MOCK_RESULTS_DIR + 'results_overview.json')
+@patch('project.models.result_storage.RESULTS_DIR', MOCK_RESULTS_DIR)
 @patch('project.models.recommender_system', RecommenderSystem('datasets', MOCK_RESULTS_DIR))
 def test_validate(client):
     """Test if the server-side validation component is functional.


### PR DESCRIPTION
Tests now use Spotify mockup data because of resent Spotify Web API policy changes that require a premium account.

In addition:
Guard against invalid result IDs in result_bp.validate() by checking
  for -1 before indexing all_results, returning a proper 400 instead
  of an unhandled IndexError